### PR TITLE
Adds support for gmail

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,15 @@
 {
   "name": "Permalinks for Google Inbox",
   "description": "Provides direct URLs to your emails, from Google Inbox.",
-  "version": "0.1",
+  "version": "0.2",
   "icons": {
     "128": "icon.png"
   },
   "content_scripts": [
     {
       "matches": [
-        "https://inbox.google.com/*"
+        "https://inbox.google.com/*",
+        "https://mail.google.com/*"
       ],
       "js": [
         "inboxsdk.js",
@@ -20,7 +21,8 @@
   "content_security_policy": "script-src 'self' https://apis.google.com; object-src 'self'",
   "permissions": [
     "identity",
-    "https://inbox.google.com/"
+    "https://inbox.google.com/",
+    "https://mail.google.com/"
   ],
   "web_accessible_resources": [
     "link.png"


### PR DESCRIPTION
This works well with the old gmail interface just by adding the mail.google.com
url to the manifest.